### PR TITLE
Bump cmake minimal version required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 project(mylisp LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
This makefile uses `TRANSFORM`, that [was introduced in version 3.12](https://cmake.org/cmake/help/latest/command/list.html#transform).  So I think 3.12 (at least, I didn't verify the rest) should be the minimal version required